### PR TITLE
Update react peer dependency to include react 17

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,10 +35,10 @@
         "babel-preset-stage-2": "^6.24.1"
     },
     "peerDependencies": {
-        "react": "^15.0.0 || ^16.0.0"
+        "react": "^15.0.0 || ^16.0.0 || ^17.0.0"
     },
     "dependencies": {
-        "@types/react": "^15.0.0 || ^16.0.0",
+        "@types/react": "^15.0.0 || ^16.0.0 || ^17.0.0",
         "prop-types": "^15.6.1"
     }
 }


### PR DESCRIPTION
There doesn't seem to be any issues for react 17 and our team would love to get rid of the warning. 🙏